### PR TITLE
added dotenv

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,20 @@
 
 A Farcaster frame demonstrating transactions.
 
+Copy .env.example to .env:
+
+```
+cp .env.example .env
+```
+
+And populate the .env file with your own values.
+
+Then run:
+
 ```
 npm install
 npm run dev
 ```
+
 
 Head to http://localhost:5173/api

--- a/lib/neynar.ts
+++ b/lib/neynar.ts
@@ -1,3 +1,5 @@
 import { NeynarAPIClient } from "@neynar/nodejs-sdk";
+import dotenv from 'dotenv';
+dotenv.config();
 
 export default new NeynarAPIClient(process.env.NEYNAR_API_KEY ?? "");

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@neynar/nodejs-sdk": "^1.11.0",
+    "dotenv": "^16.4.5",
     "frog": "latest",
     "hono": "^4",
     "viem": "^2.7.19"


### PR DESCRIPTION
`.env` file needs `dotenv` to integrate correctly. I wasn't sure where else to put the `dotenv.config();` because there is no main `index.ts` or `app.ts` file. 